### PR TITLE
Fix zsh edit-mode in tmux

### DIFF
--- a/nvim/settings/appearance.vim
+++ b/nvim/settings/appearance.vim
@@ -1,7 +1,11 @@
 " colorscheme base16-lfilho
 " let g:hybrid_custom_term_colors = 1
 " let g:hybrid_reduced_contrast = 1
-set termguicolors
+
+if has("termguicolors")
+  set termguicolors
+endif
+
 set background=dark
 
 if has("gui_running")


### PR DESCRIPTION
Fixes vim edit-mode while inside tmux.

Previously, when trying to go to`edit-mode` while in tmux, the following warning would come up 
```
Error detected while processing /Users/user/.yadr/nvim/settings/appearance.vim:
line    4:
E518: Unknown option: termguicolors
```