### PR TITLE
Adds Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+docker-compose.yml
+Dockerfile
+bin/fix_macvim_external_display.sh
+bin/iterm2-italics.sh
+bin/osx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:16.04
+LABEL maintainer="Luiz Filho <lfilho@gmail.com>"
+
+# Let the container know that there is no tty
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM xterm-256color
+
+# Bootstrapping packages needed for installation
+RUN \
+  apt-get update && \
+  apt-get install -yqq \
+    locales \
+    lsb-release \
+    software-properties-common && \
+  apt-get clean
+
+# Set locale to UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+  /usr/sbin/update-locale LANG=$LANG
+
+# Install dependencies
+# `universe` is needed for ruby
+# `security` is needed for fontconfig and fc-cache
+RUN \
+  add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe security" && \
+  add-apt-repository ppa:aacebedo/fasd && \
+  apt-get update && \
+  apt-get -yqq install \
+    autoconf \
+    build-essential \
+    curl \
+    fasd \
+    fontconfig \
+    git \
+    python \
+    python-setuptools \
+    python-dev \
+    ruby-full \
+    sudo \
+    tmux \
+    vim \
+    wget \
+    zsh && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install dotfiles
+COPY . /root/.yadr
+RUN cd /root/.yadr && rake install
+
+# Run a zsh session
+CMD [ "/bin/zsh" ]

--- a/README-lfilho.md
+++ b/README-lfilho.md
@@ -66,3 +66,16 @@ The keymaps for each plugin or behaviour can be found peeking at [doc](doc) fold
   * New brew packages
     * `diff-so-fancy`
     * `tidy5-html5`
+
+# Testing with Docker
+
+We can use Docker to test some changes in a **Linux** Container.
+
+Assuming your host system has Docker & Docker Compose properly installed, run:
+
+    docker-compose run dotfiles
+
+This will build the container image it never built it before (which may take a while -- future times will be faster) and then run a `zsh` session inside that container for you.
+There you can play around, test commands, aliases, etc.
+
+*Warning*: this repo is primarly OSX oriented. So any support for Linux can only be done with the help of the community.

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,7 @@ task :install => [:submodule_init, :submodules] do
   install_files(Dir.glob('tmux/*')) if want_to_install?('tmux config')
   install_files(Dir.glob('vimify/*')) if want_to_install?('vimification of command line tools')
   install_files(Dir.glob('{vim,vimrc}'))
+  run %{ mkdir -p ~/.config/nvim }
   run %{ ln -nfs ~/.yadr/nvim ~/.config/nvim }
   run %{ touch ~/.hushlogin }
 

--- a/Rakefile
+++ b/Rakefile
@@ -158,7 +158,7 @@ def install_prezto
   run %{ mkdir -p $HOME/.zsh.after }
   run %{ mkdir -p $HOME/.zsh.prompts }
 
-  if ENV["SHELL"].include? 'zsh' then
+  if "#{ENV['SHELL']}".include? 'zsh' then
     puts "Zsh is already configured as your shell of choice. Restart your session to load the new settings"
   else
     puts "Setting zsh as your default shell"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  dotfiles:
+    build:
+      context: .
+    image: yadr
+    volumes:
+      - ./:/root/.yadr/


### PR DESCRIPTION
Great news!

This PR introduces Docker to Yadr! A small step that opens many doors for us, IMHO.

With this in place, we can:
- Have more linux contributors contributing not only to Linux-specific support, but also to general vim and zsh stuff
- Have an automated CI build that tests the installation process, which will grant us more trust when making changes (breaking or not). (Having a "build passing"  badge in the README is also good marketing for the repo lol)

*Note*: The linux installation you can see in the `Dockerfile` is not necessarily everything a linux user needs to smoothly run Yadr. That will have to come within time from the contributions of this community. It was just the bare minimum setup to pass the installation without errors.