### PR TITLE
Create bindings for selection closer to VIM

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -61,7 +61,21 @@ set -g window-status-format "#[fg=colour235,bg=colour252,bold] #I #W "
 set -g window-status-current-format "#[fg=colour234,bg=colour39]⮀#[fg=black,bg=colour39,noreverse,bold] #{?window_zoomed_flag,#[fg=colour226],} #I: #W #[fg=colour39,bg=colour234,nobold]⮀"
 
 # Patch for OS X pbpaste and pbcopy under tmux.
-set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"
+set-option -g default-command "reattach-to-user-namespace -l zsh"
+
+# Fix VISUAL shortcuts for TMUX
+bind-key -Tedit-mode-vi Up send-keys -X history-up
+bind-key -Tedit-mode-vi Down send-keys -X history-down
+bind-key -Tcopy-mode-vi Escape send-keys -X clear-selection
+bind-key -Tcopy-mode-vi i send-keys -X cancel
+unbind-key -Tcopy-mode-vi p         ;   bind-key -Tcopy-mode-vi p send-keys -X paste-buffer
+unbind-key -Tcopy-mode-vi Space     ;   bind-key -Tcopy-mode-vi v send-keys -X begin-selection
+unbind-key -Tcopy-mode-vi V         ;   bind-key -Tcopy-mode-vi V send-keys -X start-of-line \; send-keys -X begin-selection \; send-keys -X end-of-line
+unbind-key -Tcopy-mode-vi Enter     ;   bind-key -Tcopy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+unbind-key -Tcopy-mode-vi Y         ;   bind-key -Tcopy-mode-vi Y send-keys -X start-of-line \; send-keys -X begin-selection \; send-keys -X end-of-line \; send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+unbind-key -Tcopy-mode-vi C-v       ;   bind-key -Tcopy-mode-vi C-v send-keys -X begin-selection \; send-keys -X rectangle-toggle
+unbind-key -Tcopy-mode-vi [         ;   bind-key -Tcopy-mode-vi [ send-keys -X begin-selection
+unbind-key -Tcopy-mode-vi ]         ;   bind-key -Tcopy-mode-vi ] send-keys -X copy-selection
 
 # Screen like binding
 unbind C-b

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -63,20 +63,19 @@ set -g window-status-current-format "#[fg=colour234,bg=colour39]⮀#[fg=black,bg
 # Patch for OS X pbpaste and pbcopy under tmux.
 set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"
 
-
 # Fix VISUAL shortcuts for TMUX
 bind-key -Tedit-mode-vi Up send-keys -X history-up
 bind-key -Tedit-mode-vi Down send-keys -X history-down
 bind-key -Tcopy-mode-vi Escape send-keys -X clear-selection
 bind-key -Tcopy-mode-vi i send-keys -X cancel
-unbind-key -Tcopy-mode-vi p         ;   bind-key -Tcopy-mode-vi p send-keys -X paste-buffer
-unbind-key -Tcopy-mode-vi Space     ;   bind-key -Tcopy-mode-vi v send-keys -X begin-selection
-unbind-key -Tcopy-mode-vi V         ;   bind-key -Tcopy-mode-vi V send-keys -X start-of-line \; send-keys -X begin-selection \; send-keys -X end-of-line
-unbind-key -Tcopy-mode-vi Enter     ;   bind-key -Tcopy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-unbind-key -Tcopy-mode-vi Y         ;   bind-key -Tcopy-mode-vi Y send-keys -X start-of-line \; send-keys -X begin-selection \; send-keys -X end-of-line \; send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-unbind-key -Tcopy-mode-vi C-v       ;   bind-key -Tcopy-mode-vi C-v send-keys -X begin-selection \; send-keys -X rectangle-toggle
-unbind-key -Tcopy-mode-vi [         ;   bind-key -Tcopy-mode-vi [ send-keys -X begin-selection
-unbind-key -Tcopy-mode-vi ]         ;   bind-key -Tcopy-mode-vi ] send-keys -X copy-selection
+unbind-key -Tcopy-mode-vi p         ;   bind-key -Tcopy-mode-vi p   send-keys -X paste-buffer
+unbind-key -Tcopy-mode-vi Space     ;   bind-key -Tcopy-mode-vi v   send-keys -X begin-selection
+unbind-key -Tcopy-mode-vi V         ;   bind-key -Tcopy-mode-vi V   send-keys -X start-of-line        \; send-keys -X begin-selection \; send-keys -X end-of-line
+unbind-key -Tcopy-mode-vi Enter     ;   bind-key -Tcopy-mode-vi y   send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+unbind-key -Tcopy-mode-vi Y         ;   bind-key -Tcopy-mode-vi Y   send-keys -X start-of-line        \; send-keys -X begin-selection \; send-keys -X end-of-line \; send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+unbind-key -Tcopy-mode-vi C-v       ;   bind-key -Tcopy-mode-vi C-v send-keys -X begin-selection      \; send-keys -X rectangle-toggle
+unbind-key -Tcopy-mode-vi [         ;   bind-key -Tcopy-mode-vi [   send-keys -X begin-selection
+unbind-key -Tcopy-mode-vi ]         ;   bind-key -Tcopy-mode-vi ]   send-keys -X copy-selection
 
 # Screen like binding
 unbind C-b

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -61,7 +61,8 @@ set -g window-status-format "#[fg=colour235,bg=colour252,bold] #I #W "
 set -g window-status-current-format "#[fg=colour234,bg=colour39]⮀#[fg=black,bg=colour39,noreverse,bold] #{?window_zoomed_flag,#[fg=colour226],} #I: #W #[fg=colour39,bg=colour234,nobold]⮀"
 
 # Patch for OS X pbpaste and pbcopy under tmux.
-set-option -g default-command "reattach-to-user-namespace -l zsh"
+set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"
+
 
 # Fix VISUAL shortcuts for TMUX
 bind-key -Tedit-mode-vi Up send-keys -X history-up


### PR DESCRIPTION
Add keybindings on copy-mode coherent to VIM:
- <kbd>v</kbd> - start sselection
- <kbd>V</kbd> - selects whole line
- <kbd>y</kbd> - yanks selection
- <kbd>Y</kbd> - Yanks whole line
- <kbd>Ctrl</kbd> + <kbd>v</kbd> - blockwise selection mode
- <kbd>Esc</kbd> - simply cancels selection, for exit, use <kbd>q</kbd> or - <kbd>Ctrl</kbd> + <kbd>c</kbd>